### PR TITLE
Spatial Location Task: new preference and onClick bug fix

### DIFF
--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/preferences/PreferencesManager.java
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/preferences/PreferencesManager.java
@@ -270,12 +270,13 @@ public class PreferencesManager {
         ea_variance = sharedPrefs.getInt(r.getString(R.string.preftag_ea_variance), r.getInteger(R.integer.default_ea_variance));
     }
 
-    public int sr_duration_on, sr_duration_off, sr_num_stim;
+    public int sr_duration_on, sr_duration_off, sr_num_stim, sr_locations;
 
     public void SpatialResponse() {
         sr_duration_off = sharedPrefs.getInt(r.getString(R.string.preftag_sr_duration_off), r.getInteger(R.integer.default_sr_duration_off));
         sr_duration_on = sharedPrefs.getInt(r.getString(R.string.preftag_sr_duration_on), r.getInteger(R.integer.default_sr_duration_on));
         sr_num_stim = sharedPrefs.getInt(r.getString(R.string.preftag_sr_num_stimuli), r.getInteger(R.integer.default_sr_num_stimuli));
+        sr_locations = sharedPrefs.getInt(r.getString(R.string.preftag_sr_locations), r.getInteger(R.integer.default_sr_locations));
     } 
     
     public int od_duration_on, od_duration_off, od_num_stim, od_num_distractors, od_start_delay;

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
@@ -35,6 +35,7 @@ public class TaskSpatialResponse extends Task {
     // Debug
     public static String TAG = "TaskSpatialResponse";
 
+    private static Button[] cues;
     private static int[] chosen_cues;
     private static int choice_counter;
     private static boolean[] chosen_cues_b;
@@ -43,10 +44,6 @@ public class TaskSpatialResponse extends Task {
     private static Handler h0 = new Handler();  // Show object
     private static Handler h1 = new Handler();  // Hide object
     private static Handler h2 = new Handler();  // Choice phase
-
-    private int num_positions = 8;
-    private Button[] cues = new Button[num_positions];
-
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -151,7 +148,7 @@ public class TaskSpatialResponse extends Task {
             cues[i].setHeight(75);
             cues[i].setBackgroundDrawable(drawable_grey);
             cues[i].setId(i);
-            cues[i].setOnClickListener(buttonClickListener);
+            //cues[i].setOnClickListener(buttonClickListener);
             layout.addView(cues[i]);
         }
 

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
@@ -35,16 +35,17 @@ public class TaskSpatialResponse extends Task {
     // Debug
     public static String TAG = "TaskSpatialResponse";
 
-    private static int num_positions = 8;
     private static int[] chosen_cues;
     private static int choice_counter;
     private static boolean[] chosen_cues_b;
-    private static Button[] cues = new Button[num_positions];
     GradientDrawable drawable_red, drawable_grey;
     private static PreferencesManager prefManager;
     private static Handler h0 = new Handler();  // Show object
     private static Handler h1 = new Handler();  // Hide object
     private static Handler h2 = new Handler();  // Choice phase
+
+    private int num_positions = 8;
+    private Button[] cues = new Button[num_positions];
 
 
     @Override
@@ -122,9 +123,11 @@ public class TaskSpatialResponse extends Task {
 
         choice_counter = 0;
 
+        cues = new Button[prefManager.sr_locations];
+
         // Choose cues (without replacement)
         chosen_cues = new int[prefManager.sr_num_stim];
-        chosen_cues_b = UtilsSystem.getBooleanFalseArray(num_positions);
+        chosen_cues_b = UtilsSystem.getBooleanFalseArray(prefManager.sr_locations);
 
         for (int i = 0; i < prefManager.sr_num_stim; i++) {
             chosen_cues[i] = UtilsTask.chooseValueNoReplacement(chosen_cues_b);
@@ -152,24 +155,44 @@ public class TaskSpatialResponse extends Task {
             layout.addView(cues[i]);
         }
 
-        // Position cues clockwise from 12:00
-        cues[0].setX(575);
-        cues[1].setX(775);
-        cues[2].setX(975);
-        cues[3].setX(775);
-        cues[4].setX(575);
-        cues[5].setX(375);
-        cues[6].setX(175);
-        cues[7].setX(375);
-
-        cues[0].setY(400);
-        cues[1].setY(650);
-        cues[2].setY(900);
-        cues[3].setY(1150);
-        cues[4].setY(1400);
-        cues[5].setY(1150);
-        cues[6].setY(900);
-        cues[7].setY(650);
+        switch (prefManager.sr_locations) {
+            case 2:
+                cues[0].setX(575);
+                cues[1].setX(575);
+                cues[0].setY(400);
+                cues[1].setY(1400);
+                break;
+            case 4:
+                // Position cues clockwise from 12:00
+                cues[0].setX(575);
+                cues[1].setX(975);
+                cues[2].setX(575);
+                cues[3].setX(175);
+                cues[0].setY(400);
+                cues[1].setY(900);
+                cues[2].setY(1400);
+                cues[3].setY(900);
+                break;
+            default:
+                // Position cues clockwise from 12:00
+                cues[0].setX(575);
+                cues[1].setX(775);
+                cues[2].setX(975);
+                cues[3].setX(775);
+                cues[4].setX(575);
+                cues[5].setX(375);
+                cues[6].setX(175);
+                cues[7].setX(375);
+                cues[0].setY(400);
+                cues[1].setY(650);
+                cues[2].setY(900);
+                cues[3].setY(1150);
+                cues[4].setY(1400);
+                cues[5].setY(1150);
+                cues[6].setY(900);
+                cues[7].setY(650);
+                break;
+        }
 
         UtilsTask.toggleCues(cues, false);
 

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
@@ -112,18 +112,20 @@ public class TaskSpatialResponse extends Task {
 
     }
 
-
     private void assignObjects() {
         prefManager = new PreferencesManager(getContext());
         prefManager.SpatialResponse();
 
+        int locations = prefManager.sr_locations;
+        if (locations<3) {locations=2;}else if (locations<5) {locations=4;}else {locations = 8;}
+
         choice_counter = 0;
         task_phase = 0;
-        cues = new Button[prefManager.sr_locations];
+        cues = new Button[locations];
 
         // Choose cues (without replacement)
         chosen_cues = new int[prefManager.sr_num_stim];
-        chosen_cues_b = UtilsSystem.getBooleanFalseArray(prefManager.sr_locations);
+        chosen_cues_b = UtilsSystem.getBooleanFalseArray(locations);
 
         for (int i = 0; i < prefManager.sr_num_stim; i++) {
             chosen_cues[i] = UtilsTask.chooseValueNoReplacement(chosen_cues_b);
@@ -151,7 +153,7 @@ public class TaskSpatialResponse extends Task {
             layout.addView(cues[i]);
         }
 
-        switch (prefManager.sr_locations) {
+        switch (locations) {
             case 2:
                 cues[0].setX(575);
                 cues[1].setX(575);

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
@@ -39,8 +39,7 @@ public class TaskSpatialResponse extends Task {
     private static int[] chosen_cues;
     private static int choice_counter;
     private static int task_phase;
-    private static boolean[] chosen_cues_b;
-    GradientDrawable drawable_red, drawable_grey;
+    private GradientDrawable drawable_red, drawable_grey;
     private static PreferencesManager prefManager;
     private static Handler h0 = new Handler();  // Show object
     private static Handler h1 = new Handler();  // Hide object
@@ -125,7 +124,7 @@ public class TaskSpatialResponse extends Task {
 
         // Choose cues (without replacement)
         chosen_cues = new int[prefManager.sr_num_stim];
-        chosen_cues_b = UtilsSystem.getBooleanFalseArray(locations);
+        boolean[] chosen_cues_b = UtilsSystem.getBooleanFalseArray(locations);
 
         for (int i = 0; i < prefManager.sr_num_stim; i++) {
             chosen_cues[i] = UtilsTask.chooseValueNoReplacement(chosen_cues_b);
@@ -207,7 +206,7 @@ public class TaskSpatialResponse extends Task {
         @Override
         public void onClick(View view) {
 
-            boolean correct_chosen = Integer.valueOf(view.getId()) == chosen_cues[(prefManager.sr_num_stim - choice_counter) - 1];
+            boolean correct_chosen = view.getId() == chosen_cues[(prefManager.sr_num_stim - choice_counter) - 1];
             logEvent(""+view.getId()+" cue pressed ("+correct_chosen+" answer)", callback);
             choice_counter += 1;
 
@@ -219,8 +218,8 @@ public class TaskSpatialResponse extends Task {
                 logEvent("End of trial, correct outcome:"+correct_chosen, callback);
                 endOfTrial(correct_chosen, callback);
             } else {
-                logEvent("Disabling cue"+Integer.valueOf(view.getId()), callback);
-                UtilsTask.toggleCue(cues[Integer.valueOf(view.getId())], false);
+                logEvent("Disabling cue"+view.getId(), callback);
+                UtilsTask.toggleCue(cues[view.getId()], false);
             }
         }
     };

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/individual_tasks/TaskSpatialResponse.java
@@ -98,9 +98,6 @@ public class TaskSpatialResponse extends Task {
 
                         UtilsTask.toggleCue(cues[i], true);
 
-                        // Make clickable
-                        cues[i].setOnClickListener(buttonClickListener);
-
                         // Change colour to not reveal answer!
                         GradientDrawable drawable = new GradientDrawable();
                         drawable.setShape(GradientDrawable.OVAL); //use different shape to denote a response cue

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/layout/activity_main_menu.xml
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/layout/activity_main_menu.xml
@@ -307,6 +307,7 @@
 
             <Button
                     android:id="@+id/buttonViewData"
+                    style="@style/Widget.AppCompat.Button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginVertical="16dp"

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/layout/activity_main_menu.xml
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/layout/activity_main_menu.xml
@@ -307,7 +307,6 @@
 
             <Button
                     android:id="@+id/buttonViewData"
-                    style="@style/Widget.AppCompat.Button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginVertical="16dp"

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/values/integers.xml
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/values/integers.xml
@@ -65,7 +65,7 @@
     <integer name="default_ea_distance">3</integer>
     <integer name="default_ea_variance">1</integer>
 
-    <integer name="default_sr_num_stimuli">3</integer>
+    <integer name="default_sr_num_stimuli">1</integer>
     <integer name="default_sr_locations">8</integer>
     <integer name="default_sr_duration_on">500</integer>
     <integer name="default_sr_duration_off">1500</integer>

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/values/integers.xml
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/values/integers.xml
@@ -66,6 +66,7 @@
     <integer name="default_ea_variance">1</integer>
 
     <integer name="default_sr_num_stimuli">3</integer>
+    <integer name="default_sr_locations">8</integer>
     <integer name="default_sr_duration_on">500</integer>
     <integer name="default_sr_duration_off">1500</integer>
     

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/values/strings.xml
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/values/strings.xml
@@ -195,6 +195,7 @@
     <string name="preftag_sr_duration_off">sr_duration_off</string>
     <string name="preftag_sr_duration_on">sr_duration_on</string>
     <string name="preftag_sr_num_stimuli">sr_num_stimuli</string>
+    <string name="preftag_sr_locations">sr_locations</string>
     
     <string name="preftag_od_duration_off">od_duration_off</string>
     <string name="preftag_od_duration_on">od_duration_on</string>

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/xml/preferences_task_spatialresponse.xml
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/xml/preferences_task_spatialresponse.xml
@@ -6,11 +6,16 @@
             app:key="task_settings"
             app:title="Settings for Spatial Response task">
 
+        <mymou.preferences.SeekBarPreferenceCustom
+                android:defaultValue="@integer/default_sr_locations"
+                android:max="8"
+                app:key="@string/preftag_sr_locations"
+                app:title="Number of locations" />
 
         <mymou.preferences.SeekBarPreferenceCustom
                 android:defaultValue="@integer/default_sr_num_stimuli"
                 app:key="@string/preftag_sr_num_stimuli"
-                app:title="Number of stimuli to present"
+                app:title="Number of successive stimuli to present"
                 android:max="8"/>
 
         <mymou.preferences.SeekBarPreferenceCustom

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/xml/preferences_task_spatialresponse.xml
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/xml/preferences_task_spatialresponse.xml
@@ -7,16 +7,16 @@
             app:title="Settings for Spatial Response task">
 
         <mymou.preferences.SeekBarPreferenceCustom
-                android:defaultValue="@integer/default_sr_locations"
-                android:max="8"
-                app:key="@string/preftag_sr_locations"
-                app:title="Number of locations" />
-
-        <mymou.preferences.SeekBarPreferenceCustom
                 android:defaultValue="@integer/default_sr_num_stimuli"
                 app:key="@string/preftag_sr_num_stimuli"
                 app:title="Number of successive stimuli to present"
                 android:max="8"/>
+
+        <mymou.preferences.SeekBarPreferenceCustom
+                android:defaultValue="@integer/default_sr_locations"
+                app:key="@string/preftag_sr_locations"
+                android:max="8"
+                app:title="Number of locations" />
 
         <mymou.preferences.SeekBarPreferenceCustom
                 android:defaultValue="@integer/default_sr_duration_on"

--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/xml/preferences_task_spatialresponse.xml
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/res/xml/preferences_task_spatialresponse.xml
@@ -9,14 +9,14 @@
         <mymou.preferences.SeekBarPreferenceCustom
                 android:defaultValue="@integer/default_sr_num_stimuli"
                 app:key="@string/preftag_sr_num_stimuli"
-                app:title="Number of successive stimuli to present"
+                app:title="Number of successive positions to memorise"
                 android:max="8"/>
 
         <mymou.preferences.SeekBarPreferenceCustom
                 android:defaultValue="@integer/default_sr_locations"
                 app:key="@string/preftag_sr_locations"
                 android:max="8"
-                app:title="Number of locations" />
+                app:title="Number of spatial positions (2/4/8) to chose from" />
 
         <mymou.preferences.SeekBarPreferenceCustom
                 android:defaultValue="@integer/default_sr_duration_on"


### PR DESCRIPTION
Hi James,

We were testing the spatial location task. First we noticed a bug whereby clicking the stimulus cues would reward/timeout the monkey. Second, for training we wanted to reduce the number of stimuli to start with, giving an option of 2 / 4 / 8 potential cues to remember. I managed to add a preference to control this. One small annoyance is I don't know how to limit the Seekbar to fixed values (2/4/8), at the moment you can set 3/5/6/7 etc. and it is ignored by the task and 8 is run (default).