### PR TITLE
Fix the long delay if saving images

### DIFF
--- a/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/backend/CameraSavePhoto.java
+++ b/Behavioural Testing Unit (Android)/Mymou/app/src/main/java/mymou/task/backend/CameraSavePhoto.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
 
+import mymou.preferences.PreferencesManager;
+
 /**
  * Saves linked file into linked filename
  */
@@ -78,32 +80,36 @@ class CameraSavePhoto implements Runnable {
 
         }
 
-        // Create integer array for facerecog
-        int x = bitmapCropped.getWidth();
-        int y = bitmapCropped.getHeight();
-        int[] intArray = new int[x * y];
-        bitmapCropped.getPixels(intArray, 0, x, 0, 0, x, y);
-        for (int i = 0; i < intArray.length; i++) {
-            intArray[i] = Color.red(intArray[i]); //Any colour will do as greyscale
+        PreferencesManager preferencesManager = new PreferencesManager(mContext);
+
+        if (preferencesManager.facerecog == true) {
+            // Create integer array for facerecog
+            int x = bitmapCropped.getWidth();
+            int y = bitmapCropped.getHeight();
+            int[] intArray = new int[x * y];
+            bitmapCropped.getPixels(intArray, 0, x, 0, 0, x, y);
+            for (int i = 0; i < intArray.length; i++) {
+                intArray[i] = Color.red(intArray[i]); //Any colour will do as greyscale
+            }
+
+            // Run image through faceRecog
+            TaskManager.setFaceRecogPrediction(intArray);
+            Log.d(TAG, "Face recog finished");
+
+            //Save pixel values
+            long startTime = System.currentTimeMillis();
+            saveIntArray(intArray);
+            long endTime = System.currentTimeMillis();
+            long duration = (endTime - startTime);
+            Log.d(TAG, "Integer array saved in " + duration + "ms");
         }
 
-        // Run image through faceRecog
-        TaskManager.setFaceRecogPrediction(intArray);
-        Log.d(TAG, "Face recog finished");
-
-        //Save pixel values
-        long startTime = System.currentTimeMillis();
-        saveIntArray(intArray);
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime);
-        Log.d(TAG, "Integer array saved in "+duration);
-
         //Save photo as jpeg
-        startTime = System.currentTimeMillis();
+        long startTimeb = System.currentTimeMillis();
         savePhoto(bitmapCropped);
-        endTime = System.currentTimeMillis();
-        duration = (endTime - startTime);
-        Log.d(TAG, "Cropped photo saved in "+duration);
+        long endTimeb = System.currentTimeMillis();
+        long durationb = (endTimeb - startTimeb);
+        Log.d(TAG, "Cropped photo saved in " + durationb + "ms");
 
         Log.d(TAG, "CameraSavePhoto finished successfully");
 


### PR DESCRIPTION
See #16 -- basically if you enable the camera but not face recognition, mymou still saves the int arays as text and this can take many seconds, which makes mymou block until the save is complete. All I've done is make the int array saving conditional on have `facerecog` true, so we can save a jpeg quickly.

Offtopic, I pull in a PreferencesManager to get to `facerecog` pref, and if I breakpoint that class I notice Mymou keeps calling this constantly, it keeps recreating itself many times on each trial. This doesn't  seem efficient. This class should be persistent or something like a Singleton (not sure exactly what the proper android/java way to do this is). 